### PR TITLE
Use localized shield type in CrewCabin UI

### DIFF
--- a/Assets/Scripts/Craft/Parts/Modifiers/CrewCabinData.cs
+++ b/Assets/Scripts/Craft/Parts/Modifiers/CrewCabinData.cs
@@ -132,7 +132,7 @@ namespace Assets.Scripts.Craft.Parts.Modifiers
 
 
 
-        private static string GetLocalizedShieldType(string type)
+        internal static string GetLocalizedShieldType(string type)
         {
             switch (type)
             {

--- a/Assets/Scripts/Craft/Parts/Modifiers/CrewCabinScript.cs
+++ b/Assets/Scripts/Craft/Parts/Modifiers/CrewCabinScript.cs
@@ -57,7 +57,7 @@ namespace Assets.Scripts.Craft.Parts.Modifiers
         public override void OnGenerateInspectorModel(PartInspectorModel model)
         {
             base.OnGenerateInspectorModel(model);
-            model.Add<TextModel>(new TextModel("<color=yellow>" + Locale.GetString("Droodism.CrewCabinScript.RadiationShieldType"), (Func<string>) (() =>this.Data.RadiationShieldType)));
+            model.Add<TextModel>(new TextModel("<color=yellow>" + Locale.GetString("Droodism.CrewCabinScript.RadiationShieldType"), (Func<string>) (() =>CrewCabinData.GetLocalizedShieldType(this.Data.RadiationShieldType))));
             model.Add<TextModel>(new TextModel("<color=yellow>" + Locale.GetString("Droodism.CrewCabinScript.RadiationShieldDuration"), (Func<string>) (() =>Data.RadiationShieldDurationUpperLimit==0?Locale.GetString("Droodism.DroodismUIManager.NotAvailable"):Units.GetPercentageString((float)(this.Data.RadiationShieldDuration/this.Data.RadiationShieldDurationUpperLimit)))));
             if (this.Data.RadiationShieldType == "Water" || Data.RadiationShieldType == "Liquid Hydrogen")
             {
@@ -296,7 +296,7 @@ namespace Assets.Scripts.Craft.Parts.Modifiers
 
         public override void OnGeneratePerformanceAnalysisModel(GroupModel groupModel)
         {
-            groupModel.Add<TextModel>(new TextModel("<color=yellow>" + Locale.GetString("Droodism.CrewCabinScript.RadiationShieldType") + "</color>",(Func<string>) (()=> this.Data.RadiationShieldType),tooltip: Locale.GetString("Droodism.CrewCabinScript.RadiationShieldTypeTooltip")));
+            groupModel.Add<TextModel>(new TextModel("<color=yellow>" + Locale.GetString("Droodism.CrewCabinScript.RadiationShieldType") + "</color>",(Func<string>) (()=> CrewCabinData.GetLocalizedShieldType(this.Data.RadiationShieldType)),tooltip: Locale.GetString("Droodism.CrewCabinScript.RadiationShieldTypeTooltip")));
             groupModel.Add<ProgressBarModel>(new ProgressBarModel(()=>
                 Locale.GetString("Droodism.CrewCabinScript.RadiationDuration"), 
                 () => (float)(this.Data.RadiationShieldDuration / this.Data.RadiationShieldDurationUpperLimit)));


### PR DESCRIPTION
Made GetLocalizedShieldType internal and updated CrewCabinScript to call CrewCabinData.GetLocalizedShieldType(...) where RadiationShieldType was shown (inspector and performance analysis). This replaces raw type strings with localized labels for display. Changes in Assets/Scripts/Craft/Parts/Modifiers/CrewCabinData.cs and CrewCabinScript.cs.